### PR TITLE
Lab2 and 5 edits

### DIFF
--- a/labs/lab2/readme.md
+++ b/labs/lab2/readme.md
@@ -52,10 +52,10 @@ You will run some Docker containers to build out various workshop components, us
    vJ+ADwlFXKf58bX0Qk/...6N38Al4fdxXDefT6J2iiM=
    ```
 
-1. Using the same Terminal, set the `JWT` environment variable from your `nginx-repo.jwt` license file. This is required to pull the NGINX Plus container images from the NGINX Private Registry. If you do not have an NGINX Plus license, you can request a free 30-Day Trial license from here: <https://www.f5.com/trials/nginx-one>
+1. Using the same Terminal, set the `JWT` environment variable from your NGINX One `license.jwt` file. This is required to pull the NGINX Plus container images from the NGINX Private Registry. If you do not have an NGINX One license, you can request a free 30-Day Trial license from here: <https://www.f5.com/trials/nginx-one>
 
    ```bash
-   export JWT=$(cat lab2/nginx-repo.jwt)
+   export JWT=$(cat lab2/license.jwt)
    ```
 
    And verify it was set:

--- a/labs/lab5/readme.md
+++ b/labs/lab5/readme.md
@@ -78,7 +78,7 @@ Starting with Release 33, NGINX Plus requires NGINX Agent to be installed along 
 
     After the `plus3` instance code block you will put a new block of code for the R34 release.  You will call this `plus4`, keeping in line with your naming convention for the labs.
 
-    Starting on line 75, let's uncomment this block of code (ends on line 96). A little tip, in VS Studio you can highlight the block of code and press `Ctrl` + `/` to uncomment the whole block at once.
+    Starting on line 74, let's uncomment this block of code (ends on line 96). A little tip, in VS Studio you can highlight the block of code and press `Ctrl` + `/` to uncomment the whole block at once.
 
     ```bash
     ### Uncomment the section below for Lab5
@@ -432,7 +432,7 @@ Let's take the R32 install and upgrade it. This time you will do it with assista
 
     ![NGINX Plus](media/lab5-add-license-1.png)
 
-    Copy the value from the `lab5/license.jwt` and enter it into this file. Click the `Next` button.
+    Copy the value from the `lab2/license.jwt` and enter it into this file. Click the `Next` button.
 
     >**NOTE:** Make sure you do not add any extra spaces or characters to the license file or it would be considered invalid.
 


### PR DESCRIPTION
### Proposed changes

- Renamed `nginx-repo.jwt` to `license.jwt` within lab2 guide as that is the name which is present in udf and also referred to in lab5.
- Minor lab5 corrections that was captured by field SE while going through the guide
